### PR TITLE
feat: added automatic mail reminders using cron

### DIFF
--- a/backend/cron/reminders.ts
+++ b/backend/cron/reminders.ts
@@ -1,0 +1,104 @@
+import cron from "node-cron";
+import prisma from "../lib/prisma";
+import { sendTrainingReminderEmail, sendReviewPromptEmail } from "../lib/mailer";
+
+cron.schedule("0 * * * *", async () => {
+  console.log("[CRON] Checking for notifications to send...");
+
+  const now = new Date();
+
+  const todayMidnight = new Date(now);
+  todayMidnight.setHours(0, 0, 0, 0);
+
+  const inTwoDays = new Date(todayMidnight);
+  inTwoDays.setDate(todayMidnight.getDate() + 2);
+
+  try {
+    const upcomingReservations = await prisma.trainerReservation.findMany({
+      where: {
+        status: "CONFIRMED",
+        reminderSent: false,
+        date: {
+          gte: todayMidnight,
+          lte: inTwoDays,
+        },
+      },
+      include: {
+        user: { select: { email: true } },
+        assignment: {
+          include: { trainerProfile: true },
+        },
+      },
+    });
+
+    for (const res of upcomingReservations) {
+      try {
+        const trainingStartTime = new Date(res.date);
+        trainingStartTime.setHours(res.startHour, 0, 0, 0);
+
+        const timeDiff = trainingStartTime.getTime() - now.getTime();
+
+        if (timeDiff > 0 && timeDiff <= 24 * 60 * 60 * 1000) {
+          const trainerName = `${res.assignment.trainerProfile.firstName} ${res.assignment.trainerProfile.lastName}`;
+
+          const formattedDate = res.date.toLocaleDateString("pl-PL");
+          const startTimeStr = `${res.startHour.toString().padStart(2, "0")}:00`;
+          const endTimeStr = `${res.endHour.toString().padStart(2, "0")}:00`;
+          const dateStr = `${formattedDate} w godzinach ${startTimeStr} - ${endTimeStr}`;
+
+          await sendTrainingReminderEmail(res.user.email, trainerName, dateStr);
+
+          await prisma.trainerReservation.update({
+            where: { id: res.id },
+            data: { reminderSent: true },
+          });
+          console.log(`[CRON] Sent training reminder to ${res.user.email}`);
+        }
+      } catch (err) {
+        console.error(`[CRON] Error sending trainimg reminder for reservation id: ${res.id}:`, err);
+      }
+    }
+
+    const pastReservations = await prisma.trainerReservation.findMany({
+      where: {
+        status: "DONE",
+        reviewPromptSent: false,
+        review: null,
+        date: {
+          lte: todayMidnight,
+        },
+      },
+      include: {
+        user: { select: { email: true } },
+        assignment: {
+          include: { trainerProfile: true },
+        },
+      },
+    });
+
+    for (const res of pastReservations) {
+      try {
+        const trainingEndTime = new Date(res.date);
+        trainingEndTime.setHours(res.endHour, 0, 0, 0);
+
+        if (trainingEndTime.getTime() < now.getTime()) {
+          const trainerName = `${res.assignment.trainerProfile.firstName} ${res.assignment.trainerProfile.lastName}`;
+
+          await sendReviewPromptEmail(res.user.email, trainerName);
+
+          await prisma.trainerReservation.update({
+            where: { id: res.id },
+            data: { reviewPromptSent: true },
+          });
+          console.log(`[CRON] Sent review prompt to ${res.user.email}`);
+        }
+      } catch (err) {
+        console.error(`[CRON] Error sending review prompt for reservation id: ${res.id}:`, err);
+      }
+    }
+  } catch (error) {
+    console.error("[CRON] Encountered error while processing notifications: ", error);
+  }
+});
+
+console.log("[CRON] Registered notification service.");

--- a/backend/lib/mailer.ts
+++ b/backend/lib/mailer.ts
@@ -70,3 +70,54 @@ export const sendPasswordResetEmail = async (email: string, token: string) => {
     `,
   });
 };
+
+export const sendTrainingReminderEmail = async (
+  email: string,
+  trainerName: string,
+  dateStr: string
+) => {
+  await transporter.sendMail({
+    from: `"GymApp" <${process.env.GMAIL_USER}>`,
+    to: email,
+    subject: "Przypomnienie o zbliżającym się treningu!",
+    html: `
+      <div style="font-family: sans-serif; margin: auto; max-w-md;">
+        <h2>Twój trening zbliża się wielkimi krokami! 🏋️‍♂️</h2>
+        <p>Przypominamy, że wkrótce masz zaplanowany trening z trenerem: <strong>${trainerName}</strong>.</p>
+        <p>Data i godzina rozpoczęcia: <strong>${dateStr}</strong></p>
+        <p>Przygotuj strój, weź wodę i do zobaczenia na sali!</p>
+        <p style="color: #999; font-size: 12px; margin-top: 16px;">
+          Jeśli nie możesz dotrzeć na trening, pamiętaj o anulowaniu rezerwacji w aplikacji.
+        </p>
+      </div>
+    `,
+  });
+};
+
+export const sendReviewPromptEmail = async (email: string, trainerName: string) => {
+  const reviewsUrl = `http://localhost:5173/my-reservations`;
+
+  await transporter.sendMail({
+    from: `"GymApp" <${process.env.GMAIL_USER}>`,
+    to: email,
+    subject: "Jak minął trening? Zostaw opinię!",
+    html: `
+      <div style="font-family: sans-serif; margin: auto; max-w-md;">
+        <h2>Mamy nadzieję, że twój trening się udał!</h2>
+        <p><strong>${trainerName}</strong> ceni sobie Twój feedback. Poświęć 30 sekund i oceń wczorajszy trening.</p>
+        <a href="${reviewsUrl}" style="
+          display: inline-block;
+          padding: 8px 8px;
+          background: #0ea5e9;
+          color: white;
+          border-radius: 8px;
+          text-decoration: none;
+          font-weight: bold;
+          margin-top: 10px;
+        ">
+          Oceń trenera
+        </a>
+      </div>
+    `,
+  });
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "cors": "^2.8.6",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
+        "node-cron": "^4.2.1",
         "nodemailer": "^8.0.5",
         "zesp_prog-gym_app": "file:.."
       },
@@ -20,6 +21,7 @@
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.5.0",
+        "@types/node-cron": "^3.0.11",
         "@types/nodemailer": "^8.0.0",
         "prisma": "^6.19.2",
         "ts-node": "^10.9.2",
@@ -746,6 +748,13 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/nodemailer": {
       "version": "8.0.0",
@@ -1751,6 +1760,15 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-fetch-native": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.5.0",
+    "@types/node-cron": "^3.0.11",
     "@types/nodemailer": "^8.0.0",
     "prisma": "^6.19.2",
     "ts-node": "^10.9.2",
@@ -17,6 +18,7 @@
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
+    "node-cron": "^4.2.1",
     "nodemailer": "^8.0.5",
     "zesp_prog-gym_app": "file:.."
   },

--- a/backend/prisma/migrations/20260522121707_add_cron_flags/migration.sql
+++ b/backend/prisma/migrations/20260522121707_add_cron_flags/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "TrainerReservation" ADD COLUMN     "reminderSent" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "reviewPromptSent" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -80,34 +80,34 @@ model Gym {
   phoneNumber String?
   description String?
 
-  operatingHours     GymOperatingHours[]
-  groupClasses       GroupClass[]
-  rooms              GymRoom[]
+  operatingHours GymOperatingHours[]
+  groupClasses   GroupClass[]
+  rooms          GymRoom[]
 
   members            MemberProfile[]     @relation("MemberHomeGym")
   trainerAssignments TrainerAssignment[]
   managers           User[]              @relation("ManagedGyms")
   invites            GymInviteTrainer[]
-  mainImage      String?
-  gallery        String[]
-  equipment      GymEquipment[]
+  mainImage          String?
+  gallery            String[]
+  equipment          GymEquipment[]
 }
 
 model StandardEquipment {
-  id          Int     @id @default(autoincrement())
-  name        String  @unique
-  imageUrl    String?
+  id       Int     @id @default(autoincrement())
+  name     String  @unique
+  imageUrl String?
 }
 
 model GymEquipment {
-  id          Int     @id @default(autoincrement())
-  
-  gym         Gym     @relation(fields: [gymId], references: [id], onDelete: Cascade)
-  gymId       Int
-  
-  name        String 
-  imageUrl    String? 
-  description String? 
+  id Int @id @default(autoincrement())
+
+  gym   Gym @relation(fields: [gymId], references: [id], onDelete: Cascade)
+  gymId Int
+
+  name        String
+  imageUrl    String?
+  description String?
 }
 
 model TrainerAssignment {
@@ -119,7 +119,7 @@ model TrainerAssignment {
   gym   Gym @relation(fields: [gymId], references: [id], onDelete: Cascade)
   gymId Int
 
-  createdAt      DateTime              @default(now())
+  createdAt      DateTime               @default(now())
   // Grafik trenera w ramach konkretnego zatrudnienia (na konkretnej siłowni)
   availabilities TrainerAvailability[]
   reservations   TrainerReservation[]
@@ -166,6 +166,9 @@ model TrainerReservation {
   createdAt DateTime       @default(now())
   review    TrainerReview?
 
+  reminderSent     Boolean @default(false)
+  reviewPromptSent Boolean @default(false)
+
   @@index([assignmentId, date])
   @@index([userId])
 }
@@ -205,7 +208,6 @@ model GymOperatingHours {
   @@unique([gymId, dayOfWeek])
   @@index([gymId])
 }
-
 
 model GymRoom {
   id       Int    @id @default(autoincrement())
@@ -257,7 +259,6 @@ model GroupClassInstructor {
   @@index([classId])
   @@index([assignmentId])
 }
-
 
 model TrainerReview {
   id Int @id @default(autoincrement())

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -512,6 +512,8 @@ async function seedReservations(gymMap: Record<string, number>) {
   const now = new Date();
   const pastDate = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
 
+  const tomorrow = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
   const reservationsToCreate = [
     {
       userId: members[0].user.id,
@@ -520,6 +522,7 @@ async function seedReservations(gymMap: Record<string, number>) {
       startHour: 10,
       endHour: 11,
       status: "DONE" as const,
+      reviewPromptSent: true,
     },
     {
       userId: members[1]?.user.id || members[0].user.id,
@@ -528,6 +531,7 @@ async function seedReservations(gymMap: Record<string, number>) {
       startHour: 11,
       endHour: 12,
       status: "DONE" as const,
+      reviewPromptSent: true,
     },
     {
       userId: members[0].user.id,
@@ -536,6 +540,25 @@ async function seedReservations(gymMap: Record<string, number>) {
       startHour: 12,
       endHour: 13,
       status: "DONE" as const,
+      reviewPromptSent: true,
+    },
+    {
+      userId: members[0].user.id, // klient.adam@gymapp.pl
+      assignmentId: trainers[0].id,
+      date: tomorrow,
+      startHour: now.getHours() - 2,
+      endHour: now.getHours() - 1,
+      status: "CONFIRMED" as const,
+      reminderSent: false,
+    },
+    {
+      userId: members[0].user.id, // klient.adam@gymapp.pl
+      assignmentId: trainers[0].id,
+      date: pastDate,
+      startHour: 20,
+      endHour: 21,
+      status: "DONE" as const,
+      reviewPromptSent: false,
     },
   ];
 

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -10,6 +10,7 @@ import groupClassesRoutes from "./routes/groupClasses";
 import adminRoutes from "./routes/admin";
 import path from "path";
 import reviewsRoutes from "./routes/reviews";
+import "./cron/reminders";
 
 const app = express();
 const BACKEND_PORT = 3001;


### PR DESCRIPTION
**Opis zmian**
PR dodaje system automatycznych zadań w tle który wysyła użytkownikom e-maile:
 - Z przypomnieniem o treningu (na mniej niż 24h przed rozpoczęciem)
 - Z prośbą o opinię (po upłynięciu godziny zakończenia treningu)

**Testowanie**
1. Uruchom: npm run db:setup
2. W pliku backend/cron/reminders.ts zmień na chwilę regułę czasową z " 0 * * * * " na " */10 * * * * * " (uruchamianie co 10 sekund zamiast co godzinę)
3. Opcjonalnie: Wejdź w Prisma Studio (npm run db:studio), znajdź użytkownika klient.adam@gymapp.pl w tabeli User i zmień jego email na swój prawdziwy, aby odebrać wiadomości
4. Odpal serwer (npm run dev)
5. W konsoli po 10 sekundach zobaczysz logi potwierdzające wysłanie obu maili (przypomnienie i prośbę o ocenę)
6. Pamiętaj o tym, aby zmianić regułę czasową crona z powrotem na co godzinę
